### PR TITLE
Add draft notebook for strategy C (PLIP)

### DIFF
--- a/C-plip-fingerprints/C-plip-fingerprints.ipynb
+++ b/C-plip-fingerprints/C-plip-fingerprints.ipynb
@@ -1,0 +1,5266 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "PLIP should be py3k-compatible, but there are some [issues](https://github.com/pharmai/plip/issues/48#issuecomment-609850473), so we are forced to _exceptionally_ use Python 2.7...\n",
+    "\n",
+    "Environment can be created with these instructions (a `.yml` file is not sufficient):\n",
+    "\n",
+    "```\n",
+    "conda create -n plip -c conda-forge -c openbabel openbabel=2.4 numpy lxml future jupyter notebook pandas python=2.7 tqdm\n",
+    "conda activate plip\n",
+    "pip install https://github.com/ssalentin/plip/archive/stable.zip --no-deps\n",
+    "pip install nglview\n",
+    "nglview install\n",
+    "nglview enable\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from IPython.display import display, Markdown\n",
+    "import pandas as pd\n",
+    "from tqdm.notebook import tqdm\n",
+    "from plip.modules.preparation import PDBComplex\n",
+    "from plip.modules.report import BindingSiteReport"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get only those structures that feature non-covalent ligands"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = \"../data/diamond_xchem_screen_mpro_all_pdbs\"\n",
+    "with open(os.path.join(data, \"diamond_xchem_screen_mpro_non_covalent_pdbs.dat\")) as f:\n",
+    "    non_covalent_filenames = [l.strip() for l in f if l.strip()]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "PLIP expects a PDB file. The `BindingSiteReport` class will process each detected binding site in `PDBComplex` and will create an object with the fields we are interested in:\n",
+    "\n",
+    "- `hydrophobic`\n",
+    "- `hbond`\n",
+    "- `waterbridge`\n",
+    "- `saltbridge`\n",
+    "- `pistacking`\n",
+    "- `pication`\n",
+    "- `halogen`\n",
+    "- `metal`\n",
+    "\n",
+    "These fields are divided in `<field>_features` (containing column names) and `<field>_info` (containing the actual records). If we iterate over the object retrieving the correct attribute name with `getattr()`, we can create a dictionary that can be passed to a `pandas.DataFrame` for nice overviews. Check it below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def analyze_interactions(pdbfile):\n",
+    "    protlig = PDBComplex()\n",
+    "    protlig.load_pdb(pdbfile)  # load the pdb\n",
+    "    for ligand in protlig.ligands:\n",
+    "        protlig.characterize_complex(ligand)  # find ligands and analyze interactions\n",
+    "    sites = {}\n",
+    "    for key, site in sorted(protlig.interaction_sets.items()):\n",
+    "        binding_site = BindingSiteReport(site)  # collect data about interactions\n",
+    "        # tuples of *_features and *_info will be converted to pandas df\n",
+    "        keys = \"hydrophobic\", \"hbond\", \"waterbridge\", \"saltbridge\", \"pistacking\", \"pication\", \"halogen\", \"metal\"\n",
+    "        interactions = {k: [getattr(binding_site, k+\"_features\")] + getattr(binding_site, k+\"_info\") for k in keys}\n",
+    "        sites[key] = interactions\n",
+    "    return sites\n",
+    "\n",
+    "def site_to_dataframes(site):\n",
+    "    keys = [\"hydrophobic\", \"hbond\", \"waterbridge\", \"saltbridge\", \"pistacking\", \"pication\", \"halogen\", \"metal\"] \n",
+    "    dfs = {}\n",
+    "    for key in keys:\n",
+    "        records = site[key][1:]\n",
+    "        if not records:\n",
+    "            dfs[key] = None\n",
+    "        else:\n",
+    "            dfs[key] = pd.DataFrame.from_records(records, columns=site[key][0])\n",
+    "    return dfs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "18de10186f4e4823b54edb895415243a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, max=22.0), HTML(value=u'')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "('File', '../data/diamond_xchem_screen_mpro_all_pdbs/Mpro-x0397.pdb', 'does not exist?')\n",
+      "('File', '../data/diamond_xchem_screen_mpro_all_pdbs/Mpro-x0426.pdb', 'does not exist?')\n",
+      "('File', '../data/diamond_xchem_screen_mpro_all_pdbs/Mpro-x0395.pdb', 'does not exist?')\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "interactions = {}\n",
+    "for filename in tqdm(non_covalent_filenames):\n",
+    "    full_filename = os.path.join(data, filename)\n",
+    "    if not os.path.isfile(full_filename):\n",
+    "        print(\"File\", full_filename, \"does not exist?\")\n",
+    "        continue\n",
+    "    interactions[filename] = analyze_interactions(full_filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "# Structure Mpro-x0946.pdb"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Site LIG:A:1101"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### waterbridge"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>DIST_A-W</th>\n",
+       "      <th>DIST_D-W</th>\n",
+       "      <th>DON_ANGLE</th>\n",
+       "      <th>WATER_ANGLE</th>\n",
+       "      <th>PROTISDON</th>\n",
+       "      <th>DONOR_IDX</th>\n",
+       "      <th>DONORTYPE</th>\n",
+       "      <th>ACCEPTOR_IDX</th>\n",
+       "      <th>ACCEPTORTYPE</th>\n",
+       "      <th>WATER_IDX</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "      <th>WATERCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>166</td>\n",
+       "      <td>GLU</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>4.03</td>\n",
+       "      <td>3.11</td>\n",
+       "      <td>173.92</td>\n",
+       "      <td>93.79</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1288</td>\n",
+       "      <td>Nam</td>\n",
+       "      <td>2383</td>\n",
+       "      <td>N3</td>\n",
+       "      <td>2434</td>\n",
+       "      <td>(9.554, 5.104, 22.977)</td>\n",
+       "      <td>(9.904, 2.716, 18.584)</td>\n",
+       "      <td>(9.307, 1.422, 21.348)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG DIST_A-W  \\\n",
+       "0    166     GLU        A       1101         LIG            A     4.03   \n",
+       "\n",
+       "  DIST_D-W DON_ANGLE WATER_ANGLE  PROTISDON  DONOR_IDX DONORTYPE  \\\n",
+       "0     3.11    173.92       93.79       True       1288       Nam   \n",
+       "\n",
+       "   ACCEPTOR_IDX ACCEPTORTYPE  WATER_IDX                  LIGCOO  \\\n",
+       "0          2383           N3       2434  (9.554, 5.104, 22.977)   \n",
+       "\n",
+       "                  PROTCOO                WATERCOO  \n",
+       "0  (9.904, 2.716, 18.584)  (9.307, 1.422, 21.348)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hbond"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>SIDECHAIN</th>\n",
+       "      <th>DIST_H-A</th>\n",
+       "      <th>DIST_D-A</th>\n",
+       "      <th>DON_ANGLE</th>\n",
+       "      <th>PROTISDON</th>\n",
+       "      <th>DONORIDX</th>\n",
+       "      <th>DONORTYPE</th>\n",
+       "      <th>ACCEPTORIDX</th>\n",
+       "      <th>ACCEPTORTYPE</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>166</td>\n",
+       "      <td>GLU</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>False</td>\n",
+       "      <td>1.82</td>\n",
+       "      <td>2.83</td>\n",
+       "      <td>174.51</td>\n",
+       "      <td>False</td>\n",
+       "      <td>2383</td>\n",
+       "      <td>N3</td>\n",
+       "      <td>1291</td>\n",
+       "      <td>O2</td>\n",
+       "      <td>(9.554, 5.104, 22.977)</td>\n",
+       "      <td>(10.336, 4.819, 20.27)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  SIDECHAIN  \\\n",
+       "0    166     GLU        A       1101         LIG            A      False   \n",
+       "\n",
+       "  DIST_H-A DIST_D-A DON_ANGLE  PROTISDON  DONORIDX DONORTYPE  ACCEPTORIDX  \\\n",
+       "0     1.82     2.83    174.51      False      2383        N3         1291   \n",
+       "\n",
+       "  ACCEPTORTYPE                  LIGCOO                 PROTCOO  \n",
+       "0           O2  (9.554, 5.104, 22.977)  (10.336, 4.819, 20.27)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hydrophobic"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>DIST</th>\n",
+       "      <th>LIGCARBONIDX</th>\n",
+       "      <th>PROTCARBONIDX</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>165</td>\n",
+       "      <td>MET</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>3.78</td>\n",
+       "      <td>2390</td>\n",
+       "      <td>1284</td>\n",
+       "      <td>(13.336, 2.198, 22.754)</td>\n",
+       "      <td>(12.359, 1.056, 19.282)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>189</td>\n",
+       "      <td>GLN</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>3.91</td>\n",
+       "      <td>2387</td>\n",
+       "      <td>1469</td>\n",
+       "      <td>(10.861, 2.392, 24.027)</td>\n",
+       "      <td>(11.848, 3.317, 27.693)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  DIST  \\\n",
+       "0    165     MET        A       1101         LIG            A  3.78   \n",
+       "1    189     GLN        A       1101         LIG            A  3.91   \n",
+       "\n",
+       "   LIGCARBONIDX  PROTCARBONIDX                   LIGCOO  \\\n",
+       "0          2390           1284  (13.336, 2.198, 22.754)   \n",
+       "1          2387           1469  (10.861, 2.392, 24.027)   \n",
+       "\n",
+       "                   PROTCOO  \n",
+       "0  (12.359, 1.056, 19.282)  \n",
+       "1  (11.848, 3.317, 27.693)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "# Structure Mpro-x0107.pdb"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Site LIG:A:1101"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hbond"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>SIDECHAIN</th>\n",
+       "      <th>DIST_H-A</th>\n",
+       "      <th>DIST_D-A</th>\n",
+       "      <th>DON_ANGLE</th>\n",
+       "      <th>PROTISDON</th>\n",
+       "      <th>DONORIDX</th>\n",
+       "      <th>DONORTYPE</th>\n",
+       "      <th>ACCEPTORIDX</th>\n",
+       "      <th>ACCEPTORTYPE</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>166</td>\n",
+       "      <td>GLU</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>False</td>\n",
+       "      <td>1.97</td>\n",
+       "      <td>2.93</td>\n",
+       "      <td>165.31</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1288</td>\n",
+       "      <td>Nam</td>\n",
+       "      <td>2393</td>\n",
+       "      <td>O2</td>\n",
+       "      <td>(9.346, 0.96, 20.955)</td>\n",
+       "      <td>(9.663, 2.532, 18.498)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  SIDECHAIN  \\\n",
+       "0    166     GLU        A       1101         LIG            A      False   \n",
+       "\n",
+       "  DIST_H-A DIST_D-A DON_ANGLE  PROTISDON  DONORIDX DONORTYPE  ACCEPTORIDX  \\\n",
+       "0     1.97     2.93    165.31       True      1288       Nam         2393   \n",
+       "\n",
+       "  ACCEPTORTYPE                 LIGCOO                 PROTCOO  \n",
+       "0           O2  (9.346, 0.96, 20.955)  (9.663, 2.532, 18.498)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hydrophobic"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>DIST</th>\n",
+       "      <th>LIGCARBONIDX</th>\n",
+       "      <th>PROTCARBONIDX</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>166</td>\n",
+       "      <td>GLU</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>3.96</td>\n",
+       "      <td>2388</td>\n",
+       "      <td>1292</td>\n",
+       "      <td>(4.96, 1.058, 19.367)</td>\n",
+       "      <td>(7.648, 3.931, 18.879)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  DIST  \\\n",
+       "0    166     GLU        A       1101         LIG            A  3.96   \n",
+       "\n",
+       "   LIGCARBONIDX  PROTCARBONIDX                 LIGCOO                 PROTCOO  \n",
+       "0          2388           1292  (4.96, 1.058, 19.367)  (7.648, 3.931, 18.879)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "# Structure Mpro-x0354.pdb"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Site LIG:A:701"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### pistacking"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>CENTDIST</th>\n",
+       "      <th>ANGLE</th>\n",
+       "      <th>OFFSET</th>\n",
+       "      <th>TYPE</th>\n",
+       "      <th>LIG_IDX_LIST</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>41</td>\n",
+       "      <td>HIS</td>\n",
+       "      <td>A</td>\n",
+       "      <td>701</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>4.82</td>\n",
+       "      <td>75.36</td>\n",
+       "      <td>0.64</td>\n",
+       "      <td>T</td>\n",
+       "      <td>2510,2511,2513,2514,2521,2522</td>\n",
+       "      <td>(11.218166666666667, -1.441, 24.432)</td>\n",
+       "      <td>(11.959999999999999, -4.989599999999999, 21.2556)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG CENTDIST  ANGLE  \\\n",
+       "0     41     HIS        A        701         LIG            A     4.82  75.36   \n",
+       "\n",
+       "  OFFSET TYPE                   LIG_IDX_LIST  \\\n",
+       "0   0.64    T  2510,2511,2513,2514,2521,2522   \n",
+       "\n",
+       "                                 LIGCOO  \\\n",
+       "0  (11.218166666666667, -1.441, 24.432)   \n",
+       "\n",
+       "                                             PROTCOO  \n",
+       "0  (11.959999999999999, -4.989599999999999, 21.2556)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hydrophobic"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>DIST</th>\n",
+       "      <th>LIGCARBONIDX</th>\n",
+       "      <th>PROTCARBONIDX</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>41</td>\n",
+       "      <td>HIS</td>\n",
+       "      <td>A</td>\n",
+       "      <td>701</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>3.86</td>\n",
+       "      <td>2510</td>\n",
+       "      <td>319</td>\n",
+       "      <td>(11.769, -2.569, 23.891)</td>\n",
+       "      <td>(13.888, -5.653, 22.94)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  DIST  \\\n",
+       "0     41     HIS        A        701         LIG            A  3.86   \n",
+       "\n",
+       "   LIGCARBONIDX  PROTCARBONIDX                    LIGCOO  \\\n",
+       "0          2510            319  (11.769, -2.569, 23.891)   \n",
+       "\n",
+       "                   PROTCOO  \n",
+       "0  (13.888, -5.653, 22.94)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "# Structure Mpro-x0072.pdb"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Site LIG:A:1101"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hbond"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>SIDECHAIN</th>\n",
+       "      <th>DIST_H-A</th>\n",
+       "      <th>DIST_D-A</th>\n",
+       "      <th>DON_ANGLE</th>\n",
+       "      <th>PROTISDON</th>\n",
+       "      <th>DONORIDX</th>\n",
+       "      <th>DONORTYPE</th>\n",
+       "      <th>ACCEPTORIDX</th>\n",
+       "      <th>ACCEPTORTYPE</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>25</td>\n",
+       "      <td>THR</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>True</td>\n",
+       "      <td>3.27</td>\n",
+       "      <td>3.78</td>\n",
+       "      <td>115.00</td>\n",
+       "      <td>True</td>\n",
+       "      <td>178</td>\n",
+       "      <td>O3</td>\n",
+       "      <td>2393</td>\n",
+       "      <td>O2</td>\n",
+       "      <td>(9.235, -5.584, 26.122)</td>\n",
+       "      <td>(8.019, -9.051, 27.017)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  SIDECHAIN  \\\n",
+       "0     25     THR        A       1101         LIG            A       True   \n",
+       "\n",
+       "  DIST_H-A DIST_D-A DON_ANGLE  PROTISDON  DONORIDX DONORTYPE  ACCEPTORIDX  \\\n",
+       "0     3.27     3.78    115.00       True       178        O3         2393   \n",
+       "\n",
+       "  ACCEPTORTYPE                   LIGCOO                  PROTCOO  \n",
+       "0           O2  (9.235, -5.584, 26.122)  (8.019, -9.051, 27.017)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### pistacking"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>CENTDIST</th>\n",
+       "      <th>ANGLE</th>\n",
+       "      <th>OFFSET</th>\n",
+       "      <th>TYPE</th>\n",
+       "      <th>LIG_IDX_LIST</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>41</td>\n",
+       "      <td>HIS</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>4.80</td>\n",
+       "      <td>79.18</td>\n",
+       "      <td>1.16</td>\n",
+       "      <td>T</td>\n",
+       "      <td>2386,2387,2388,2389,2390,2391</td>\n",
+       "      <td>(12.043333333333335, -0.7759999999999999, 23.4...</td>\n",
+       "      <td>(11.8164, -5.1314, 21.399800000000003)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG CENTDIST  ANGLE  \\\n",
+       "0     41     HIS        A       1101         LIG            A     4.80  79.18   \n",
+       "\n",
+       "  OFFSET TYPE                   LIG_IDX_LIST  \\\n",
+       "0   1.16    T  2386,2387,2388,2389,2390,2391   \n",
+       "\n",
+       "                                              LIGCOO  \\\n",
+       "0  (12.043333333333335, -0.7759999999999999, 23.4...   \n",
+       "\n",
+       "                                  PROTCOO  \n",
+       "0  (11.8164, -5.1314, 21.399800000000003)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hydrophobic"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>DIST</th>\n",
+       "      <th>LIGCARBONIDX</th>\n",
+       "      <th>PROTCARBONIDX</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>189</td>\n",
+       "      <td>GLN</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>3.86</td>\n",
+       "      <td>2388</td>\n",
+       "      <td>1468</td>\n",
+       "      <td>(12.358, 0.271, 24.254)</td>\n",
+       "      <td>(12.928, 2.477, 27.368)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  DIST  \\\n",
+       "0    189     GLN        A       1101         LIG            A  3.86   \n",
+       "\n",
+       "   LIGCARBONIDX  PROTCARBONIDX                   LIGCOO  \\\n",
+       "0          2388           1468  (12.358, 0.271, 24.254)   \n",
+       "\n",
+       "                   PROTCOO  \n",
+       "0  (12.928, 2.477, 27.368)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "# Structure Mpro-x0161.pdb"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Site LIG:A:1101"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### waterbridge"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>DIST_A-W</th>\n",
+       "      <th>DIST_D-W</th>\n",
+       "      <th>DON_ANGLE</th>\n",
+       "      <th>WATER_ANGLE</th>\n",
+       "      <th>PROTISDON</th>\n",
+       "      <th>DONOR_IDX</th>\n",
+       "      <th>DONORTYPE</th>\n",
+       "      <th>ACCEPTOR_IDX</th>\n",
+       "      <th>ACCEPTORTYPE</th>\n",
+       "      <th>WATER_IDX</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "      <th>WATERCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>166</td>\n",
+       "      <td>GLU</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>4.01</td>\n",
+       "      <td>2.87</td>\n",
+       "      <td>172.42</td>\n",
+       "      <td>89.78</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1288</td>\n",
+       "      <td>Nam</td>\n",
+       "      <td>2391</td>\n",
+       "      <td>N3</td>\n",
+       "      <td>2433</td>\n",
+       "      <td>(9.311, 5.041, 22.782)</td>\n",
+       "      <td>(9.967, 2.685, 18.385)</td>\n",
+       "      <td>(9.274, 1.499, 20.904)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG DIST_A-W  \\\n",
+       "0    166     GLU        A       1101         LIG            A     4.01   \n",
+       "\n",
+       "  DIST_D-W DON_ANGLE WATER_ANGLE  PROTISDON  DONOR_IDX DONORTYPE  \\\n",
+       "0     2.87    172.42       89.78       True       1288       Nam   \n",
+       "\n",
+       "   ACCEPTOR_IDX ACCEPTORTYPE  WATER_IDX                  LIGCOO  \\\n",
+       "0          2391           N3       2433  (9.311, 5.041, 22.782)   \n",
+       "\n",
+       "                  PROTCOO                WATERCOO  \n",
+       "0  (9.967, 2.685, 18.385)  (9.274, 1.499, 20.904)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### saltbridge"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>DIST</th>\n",
+       "      <th>PROTISPOS</th>\n",
+       "      <th>LIG_GROUP</th>\n",
+       "      <th>LIG_IDX_LIST</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>41</td>\n",
+       "      <td>HIS</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>5.18</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Carboxylate</td>\n",
+       "      <td>2392,2393</td>\n",
+       "      <td>(13.9435, -0.877, 23.3495)</td>\n",
+       "      <td>(11.7745, -4.8115000000000006, 20.7695)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  DIST  \\\n",
+       "0     41     HIS        A       1101         LIG            A  5.18   \n",
+       "\n",
+       "   PROTISPOS    LIG_GROUP LIG_IDX_LIST                      LIGCOO  \\\n",
+       "0       True  Carboxylate    2392,2393  (13.9435, -0.877, 23.3495)   \n",
+       "\n",
+       "                                   PROTCOO  \n",
+       "0  (11.7745, -4.8115000000000006, 20.7695)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hbond"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>SIDECHAIN</th>\n",
+       "      <th>DIST_H-A</th>\n",
+       "      <th>DIST_D-A</th>\n",
+       "      <th>DON_ANGLE</th>\n",
+       "      <th>PROTISDON</th>\n",
+       "      <th>DONORIDX</th>\n",
+       "      <th>DONORTYPE</th>\n",
+       "      <th>ACCEPTORIDX</th>\n",
+       "      <th>ACCEPTORTYPE</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>189</td>\n",
+       "      <td>GLN</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>True</td>\n",
+       "      <td>3.08</td>\n",
+       "      <td>3.67</td>\n",
+       "      <td>120.00</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1472</td>\n",
+       "      <td>Nam</td>\n",
+       "      <td>2395</td>\n",
+       "      <td>O2</td>\n",
+       "      <td>(10.485, 5.379, 25.107)</td>\n",
+       "      <td>(10.139, 4.011, 28.5)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>166</td>\n",
+       "      <td>GLU</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>False</td>\n",
+       "      <td>2.01</td>\n",
+       "      <td>2.99</td>\n",
+       "      <td>161.20</td>\n",
+       "      <td>False</td>\n",
+       "      <td>2391</td>\n",
+       "      <td>N3</td>\n",
+       "      <td>1291</td>\n",
+       "      <td>O2</td>\n",
+       "      <td>(9.311, 5.041, 22.782)</td>\n",
+       "      <td>(10.444, 4.777, 20.029)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  SIDECHAIN  \\\n",
+       "0    189     GLN        A       1101         LIG            A       True   \n",
+       "1    166     GLU        A       1101         LIG            A      False   \n",
+       "\n",
+       "  DIST_H-A DIST_D-A DON_ANGLE  PROTISDON  DONORIDX DONORTYPE  ACCEPTORIDX  \\\n",
+       "0     3.08     3.67    120.00       True      1472       Nam         2395   \n",
+       "1     2.01     2.99    161.20      False      2391        N3         1291   \n",
+       "\n",
+       "  ACCEPTORTYPE                   LIGCOO                  PROTCOO  \n",
+       "0           O2  (10.485, 5.379, 25.107)    (10.139, 4.011, 28.5)  \n",
+       "1           O2   (9.311, 5.041, 22.782)  (10.444, 4.777, 20.029)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hydrophobic"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>DIST</th>\n",
+       "      <th>LIGCARBONIDX</th>\n",
+       "      <th>PROTCARBONIDX</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>165</td>\n",
+       "      <td>MET</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>3.96</td>\n",
+       "      <td>2390</td>\n",
+       "      <td>1284</td>\n",
+       "      <td>(13.459, 2.162, 22.819)</td>\n",
+       "      <td>(12.458, 1.105, 19.137)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>189</td>\n",
+       "      <td>GLN</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>3.75</td>\n",
+       "      <td>2386</td>\n",
+       "      <td>1468</td>\n",
+       "      <td>(11.707, 1.106, 24.084)</td>\n",
+       "      <td>(13.298, 2.52, 27.177)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>189</td>\n",
+       "      <td>GLN</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>3.68</td>\n",
+       "      <td>2387</td>\n",
+       "      <td>1469</td>\n",
+       "      <td>(11.044, 2.322, 24.179)</td>\n",
+       "      <td>(12.243, 3.597, 27.411)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  DIST  \\\n",
+       "0    165     MET        A       1101         LIG            A  3.96   \n",
+       "1    189     GLN        A       1101         LIG            A  3.75   \n",
+       "2    189     GLN        A       1101         LIG            A  3.68   \n",
+       "\n",
+       "   LIGCARBONIDX  PROTCARBONIDX                   LIGCOO  \\\n",
+       "0          2390           1284  (13.459, 2.162, 22.819)   \n",
+       "1          2386           1468  (11.707, 1.106, 24.084)   \n",
+       "2          2387           1469  (11.044, 2.322, 24.179)   \n",
+       "\n",
+       "                   PROTCOO  \n",
+       "0  (12.458, 1.105, 19.137)  \n",
+       "1   (13.298, 2.52, 27.177)  \n",
+       "2  (12.243, 3.597, 27.411)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "# Structure Mpro-x0104.pdb"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Site LIG:A:1101"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hbond"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>SIDECHAIN</th>\n",
+       "      <th>DIST_H-A</th>\n",
+       "      <th>DIST_D-A</th>\n",
+       "      <th>DON_ANGLE</th>\n",
+       "      <th>PROTISDON</th>\n",
+       "      <th>DONORIDX</th>\n",
+       "      <th>DONORTYPE</th>\n",
+       "      <th>ACCEPTORIDX</th>\n",
+       "      <th>ACCEPTORTYPE</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>190</td>\n",
+       "      <td>THR</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>False</td>\n",
+       "      <td>3.16</td>\n",
+       "      <td>3.81</td>\n",
+       "      <td>124.31</td>\n",
+       "      <td>False</td>\n",
+       "      <td>2396</td>\n",
+       "      <td>Nam</td>\n",
+       "      <td>1476</td>\n",
+       "      <td>O2</td>\n",
+       "      <td>(12.067, 5.468, 23.761)</td>\n",
+       "      <td>(15.692, 6.519, 24.25)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>189</td>\n",
+       "      <td>GLN</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>True</td>\n",
+       "      <td>3.51</td>\n",
+       "      <td>3.96</td>\n",
+       "      <td>110.23</td>\n",
+       "      <td>False</td>\n",
+       "      <td>2397</td>\n",
+       "      <td>Nar</td>\n",
+       "      <td>1471</td>\n",
+       "      <td>O2</td>\n",
+       "      <td>(10.416, 1.465, 24.34)</td>\n",
+       "      <td>(10.199, 1.734, 28.289)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  SIDECHAIN  \\\n",
+       "0    190     THR        A       1101         LIG            A      False   \n",
+       "1    189     GLN        A       1101         LIG            A       True   \n",
+       "\n",
+       "  DIST_H-A DIST_D-A DON_ANGLE  PROTISDON  DONORIDX DONORTYPE  ACCEPTORIDX  \\\n",
+       "0     3.16     3.81    124.31      False      2396       Nam         1476   \n",
+       "1     3.51     3.96    110.23      False      2397       Nar         1471   \n",
+       "\n",
+       "  ACCEPTORTYPE                   LIGCOO                  PROTCOO  \n",
+       "0           O2  (12.067, 5.468, 23.761)   (15.692, 6.519, 24.25)  \n",
+       "1           O2   (10.416, 1.465, 24.34)  (10.199, 1.734, 28.289)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### pistacking"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>CENTDIST</th>\n",
+       "      <th>ANGLE</th>\n",
+       "      <th>OFFSET</th>\n",
+       "      <th>TYPE</th>\n",
+       "      <th>LIG_IDX_LIST</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>41</td>\n",
+       "      <td>HIS</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>5.03</td>\n",
+       "      <td>77.98</td>\n",
+       "      <td>1.74</td>\n",
+       "      <td>T</td>\n",
+       "      <td>2389,2390,2391,2392,2393,2394</td>\n",
+       "      <td>(11.979, -0.32616666666666666, 22.96666666666667)</td>\n",
+       "      <td>(11.515, -5.099600000000001, 21.4428)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG CENTDIST  ANGLE  \\\n",
+       "0     41     HIS        A       1101         LIG            A     5.03  77.98   \n",
+       "\n",
+       "  OFFSET TYPE                   LIG_IDX_LIST  \\\n",
+       "0   1.74    T  2389,2390,2391,2392,2393,2394   \n",
+       "\n",
+       "                                              LIGCOO  \\\n",
+       "0  (11.979, -0.32616666666666666, 22.96666666666667)   \n",
+       "\n",
+       "                                 PROTCOO  \n",
+       "0  (11.515, -5.099600000000001, 21.4428)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hydrophobic"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>DIST</th>\n",
+       "      <th>LIGCARBONIDX</th>\n",
+       "      <th>PROTCARBONIDX</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>189</td>\n",
+       "      <td>GLN</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>3.91</td>\n",
+       "      <td>2387</td>\n",
+       "      <td>1468</td>\n",
+       "      <td>(12.151, 2.44, 23.396)</td>\n",
+       "      <td>(12.716, 2.386, 27.269)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>165</td>\n",
+       "      <td>MET</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>3.37</td>\n",
+       "      <td>2393</td>\n",
+       "      <td>1284</td>\n",
+       "      <td>(13.096, 0.246, 22.356)</td>\n",
+       "      <td>(12.168, 1.081, 19.222)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  DIST  \\\n",
+       "0    189     GLN        A       1101         LIG            A  3.91   \n",
+       "1    165     MET        A       1101         LIG            A  3.37   \n",
+       "\n",
+       "   LIGCARBONIDX  PROTCARBONIDX                   LIGCOO  \\\n",
+       "0          2387           1468   (12.151, 2.44, 23.396)   \n",
+       "1          2393           1284  (13.096, 0.246, 22.356)   \n",
+       "\n",
+       "                   PROTCOO  \n",
+       "0  (12.716, 2.386, 27.269)  \n",
+       "1  (12.168, 1.081, 19.222)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "# Structure Mpro-x1093.pdb"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Site LIG:A:1101"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### waterbridge"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>DIST_A-W</th>\n",
+       "      <th>DIST_D-W</th>\n",
+       "      <th>DON_ANGLE</th>\n",
+       "      <th>WATER_ANGLE</th>\n",
+       "      <th>PROTISDON</th>\n",
+       "      <th>DONOR_IDX</th>\n",
+       "      <th>DONORTYPE</th>\n",
+       "      <th>ACCEPTOR_IDX</th>\n",
+       "      <th>ACCEPTORTYPE</th>\n",
+       "      <th>WATER_IDX</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "      <th>WATERCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>189</td>\n",
+       "      <td>GLN</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>4.00</td>\n",
+       "      <td>3.46</td>\n",
+       "      <td>159.02</td>\n",
+       "      <td>89.58</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1486</td>\n",
+       "      <td>Nam</td>\n",
+       "      <td>2447</td>\n",
+       "      <td>O2</td>\n",
+       "      <td>2636</td>\n",
+       "      <td>(9.135, 1.338, 21.148)</td>\n",
+       "      <td>(9.617, 2.175, 26.575)</td>\n",
+       "      <td>(7.034, 1.086, 24.544)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG DIST_A-W  \\\n",
+       "0    189     GLN        A       1101         LIG            A     4.00   \n",
+       "\n",
+       "  DIST_D-W DON_ANGLE WATER_ANGLE  PROTISDON  DONOR_IDX DONORTYPE  \\\n",
+       "0     3.46    159.02       89.58       True       1486       Nam   \n",
+       "\n",
+       "   ACCEPTOR_IDX ACCEPTORTYPE  WATER_IDX                  LIGCOO  \\\n",
+       "0          2447           O2       2636  (9.135, 1.338, 21.148)   \n",
+       "\n",
+       "                  PROTCOO                WATERCOO  \n",
+       "0  (9.617, 2.175, 26.575)  (7.034, 1.086, 24.544)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hbond"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>SIDECHAIN</th>\n",
+       "      <th>DIST_H-A</th>\n",
+       "      <th>DIST_D-A</th>\n",
+       "      <th>DON_ANGLE</th>\n",
+       "      <th>PROTISDON</th>\n",
+       "      <th>DONORIDX</th>\n",
+       "      <th>DONORTYPE</th>\n",
+       "      <th>ACCEPTORIDX</th>\n",
+       "      <th>ACCEPTORTYPE</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>166</td>\n",
+       "      <td>GLU</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>False</td>\n",
+       "      <td>2.03</td>\n",
+       "      <td>3.01</td>\n",
+       "      <td>171.69</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1302</td>\n",
+       "      <td>Nam</td>\n",
+       "      <td>2447</td>\n",
+       "      <td>O2</td>\n",
+       "      <td>(9.135, 1.338, 21.148)</td>\n",
+       "      <td>(9.719, 2.676, 18.521)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  SIDECHAIN  \\\n",
+       "0    166     GLU        A       1101         LIG            A      False   \n",
+       "\n",
+       "  DIST_H-A DIST_D-A DON_ANGLE  PROTISDON  DONORIDX DONORTYPE  ACCEPTORIDX  \\\n",
+       "0     2.03     3.01    171.69       True      1302       Nam         2447   \n",
+       "\n",
+       "  ACCEPTORTYPE                  LIGCOO                 PROTCOO  \n",
+       "0           O2  (9.135, 1.338, 21.148)  (9.719, 2.676, 18.521)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "# Structure Mpro-x1077.pdb"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Site LIG:A:1101"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hbond"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>SIDECHAIN</th>\n",
+       "      <th>DIST_H-A</th>\n",
+       "      <th>DIST_D-A</th>\n",
+       "      <th>DON_ANGLE</th>\n",
+       "      <th>PROTISDON</th>\n",
+       "      <th>DONORIDX</th>\n",
+       "      <th>DONORTYPE</th>\n",
+       "      <th>ACCEPTORIDX</th>\n",
+       "      <th>ACCEPTORTYPE</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>166</td>\n",
+       "      <td>GLU</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>False</td>\n",
+       "      <td>2.07</td>\n",
+       "      <td>3.03</td>\n",
+       "      <td>164.49</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1288</td>\n",
+       "      <td>Nam</td>\n",
+       "      <td>2383</td>\n",
+       "      <td>N1</td>\n",
+       "      <td>(9.978, 1.48, 21.333)</td>\n",
+       "      <td>(9.961, 2.675, 18.544)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  SIDECHAIN  \\\n",
+       "0    166     GLU        A       1101         LIG            A      False   \n",
+       "\n",
+       "  DIST_H-A DIST_D-A DON_ANGLE  PROTISDON  DONORIDX DONORTYPE  ACCEPTORIDX  \\\n",
+       "0     2.07     3.03    164.49       True      1288       Nam         2383   \n",
+       "\n",
+       "  ACCEPTORTYPE                 LIGCOO                 PROTCOO  \n",
+       "0           N1  (9.978, 1.48, 21.333)  (9.961, 2.675, 18.544)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### pistacking"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>CENTDIST</th>\n",
+       "      <th>ANGLE</th>\n",
+       "      <th>OFFSET</th>\n",
+       "      <th>TYPE</th>\n",
+       "      <th>LIG_IDX_LIST</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>41</td>\n",
+       "      <td>HIS</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>4.77</td>\n",
+       "      <td>89.86</td>\n",
+       "      <td>1.34</td>\n",
+       "      <td>T</td>\n",
+       "      <td>2386,2388,2389,2390,2391,2396</td>\n",
+       "      <td>(9.587666666666665, -1.7124999999999997, 23.5445)</td>\n",
+       "      <td>(11.974799999999998, -5.0318, 21.091)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG CENTDIST  ANGLE  \\\n",
+       "0     41     HIS        A       1101         LIG            A     4.77  89.86   \n",
+       "\n",
+       "  OFFSET TYPE                   LIG_IDX_LIST  \\\n",
+       "0   1.34    T  2386,2388,2389,2390,2391,2396   \n",
+       "\n",
+       "                                              LIGCOO  \\\n",
+       "0  (9.587666666666665, -1.7124999999999997, 23.5445)   \n",
+       "\n",
+       "                                 PROTCOO  \n",
+       "0  (11.974799999999998, -5.0318, 21.091)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hydrophobic"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>DIST</th>\n",
+       "      <th>LIGCARBONIDX</th>\n",
+       "      <th>PROTCARBONIDX</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>25</td>\n",
+       "      <td>THR</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>3.38</td>\n",
+       "      <td>2393</td>\n",
+       "      <td>179</td>\n",
+       "      <td>(8.975, -5.856, 23.587)</td>\n",
+       "      <td>(7.829, -8.893, 24.538)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  DIST  \\\n",
+       "0     25     THR        A       1101         LIG            A  3.38   \n",
+       "\n",
+       "   LIGCARBONIDX  PROTCARBONIDX                   LIGCOO  \\\n",
+       "0          2393            179  (8.975, -5.856, 23.587)   \n",
+       "\n",
+       "                   PROTCOO  \n",
+       "0  (7.829, -8.893, 24.538)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "# Structure Mpro-x0967.pdb"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Site LIG:A:1101"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hbond"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>SIDECHAIN</th>\n",
+       "      <th>DIST_H-A</th>\n",
+       "      <th>DIST_D-A</th>\n",
+       "      <th>DON_ANGLE</th>\n",
+       "      <th>PROTISDON</th>\n",
+       "      <th>DONORIDX</th>\n",
+       "      <th>DONORTYPE</th>\n",
+       "      <th>ACCEPTORIDX</th>\n",
+       "      <th>ACCEPTORTYPE</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>166</td>\n",
+       "      <td>GLU</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>False</td>\n",
+       "      <td>2.45</td>\n",
+       "      <td>3.38</td>\n",
+       "      <td>159.01</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1288</td>\n",
+       "      <td>Nam</td>\n",
+       "      <td>2401</td>\n",
+       "      <td>O2</td>\n",
+       "      <td>(9.866, 1.017, 21.611)</td>\n",
+       "      <td>(9.749, 2.544, 18.594)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>144</td>\n",
+       "      <td>SER</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>True</td>\n",
+       "      <td>3.17</td>\n",
+       "      <td>3.50</td>\n",
+       "      <td>102.20</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1121</td>\n",
+       "      <td>O3</td>\n",
+       "      <td>2400</td>\n",
+       "      <td>O3</td>\n",
+       "      <td>(5.702, 0.784, 16.93)</td>\n",
+       "      <td>(4.607, -2.264, 15.598)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>163</td>\n",
+       "      <td>HIS</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>True</td>\n",
+       "      <td>2.22</td>\n",
+       "      <td>3.05</td>\n",
+       "      <td>147.85</td>\n",
+       "      <td>False</td>\n",
+       "      <td>2400</td>\n",
+       "      <td>O3</td>\n",
+       "      <td>1269</td>\n",
+       "      <td>Nar</td>\n",
+       "      <td>(5.702, 0.784, 16.93)</td>\n",
+       "      <td>(8.069, -0.282, 15.326)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>166</td>\n",
+       "      <td>GLU</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>False</td>\n",
+       "      <td>2.60</td>\n",
+       "      <td>3.48</td>\n",
+       "      <td>148.07</td>\n",
+       "      <td>False</td>\n",
+       "      <td>2397</td>\n",
+       "      <td>Nam</td>\n",
+       "      <td>1291</td>\n",
+       "      <td>O2</td>\n",
+       "      <td>(7.991, 2.594, 22.44)</td>\n",
+       "      <td>(9.994, 4.559, 20.389)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  SIDECHAIN  \\\n",
+       "0    166     GLU        A       1101         LIG            A      False   \n",
+       "1    144     SER        A       1101         LIG            A       True   \n",
+       "2    163     HIS        A       1101         LIG            A       True   \n",
+       "3    166     GLU        A       1101         LIG            A      False   \n",
+       "\n",
+       "  DIST_H-A DIST_D-A DON_ANGLE  PROTISDON  DONORIDX DONORTYPE  ACCEPTORIDX  \\\n",
+       "0     2.45     3.38    159.01       True      1288       Nam         2401   \n",
+       "1     3.17     3.50    102.20       True      1121        O3         2400   \n",
+       "2     2.22     3.05    147.85      False      2400        O3         1269   \n",
+       "3     2.60     3.48    148.07      False      2397       Nam         1291   \n",
+       "\n",
+       "  ACCEPTORTYPE                  LIGCOO                  PROTCOO  \n",
+       "0           O2  (9.866, 1.017, 21.611)   (9.749, 2.544, 18.594)  \n",
+       "1           O3   (5.702, 0.784, 16.93)  (4.607, -2.264, 15.598)  \n",
+       "2          Nar   (5.702, 0.784, 16.93)  (8.069, -0.282, 15.326)  \n",
+       "3           O2   (7.991, 2.594, 22.44)   (9.994, 4.559, 20.389)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hydrophobic"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>DIST</th>\n",
+       "      <th>LIGCARBONIDX</th>\n",
+       "      <th>PROTCARBONIDX</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>165</td>\n",
+       "      <td>MET</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>3.99</td>\n",
+       "      <td>2387</td>\n",
+       "      <td>1284</td>\n",
+       "      <td>(11.351, -1.592, 22.376)</td>\n",
+       "      <td>(12.152, 0.87, 19.344)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>166</td>\n",
+       "      <td>GLU</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>3.49</td>\n",
+       "      <td>2394</td>\n",
+       "      <td>1292</td>\n",
+       "      <td>(5.174, 1.599, 19.108)</td>\n",
+       "      <td>(7.726, 3.899, 18.494)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  DIST  \\\n",
+       "0    165     MET        A       1101         LIG            A  3.99   \n",
+       "1    166     GLU        A       1101         LIG            A  3.49   \n",
+       "\n",
+       "   LIGCARBONIDX  PROTCARBONIDX                    LIGCOO  \\\n",
+       "0          2387           1284  (11.351, -1.592, 22.376)   \n",
+       "1          2394           1292    (5.174, 1.599, 19.108)   \n",
+       "\n",
+       "                  PROTCOO  \n",
+       "0  (12.152, 0.87, 19.344)  \n",
+       "1  (7.726, 3.899, 18.494)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "# Structure Mpro-x0995.pdb"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Site LIG:A:1101"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### waterbridge"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>DIST_A-W</th>\n",
+       "      <th>DIST_D-W</th>\n",
+       "      <th>DON_ANGLE</th>\n",
+       "      <th>WATER_ANGLE</th>\n",
+       "      <th>PROTISDON</th>\n",
+       "      <th>DONOR_IDX</th>\n",
+       "      <th>DONORTYPE</th>\n",
+       "      <th>ACCEPTOR_IDX</th>\n",
+       "      <th>ACCEPTORTYPE</th>\n",
+       "      <th>WATER_IDX</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "      <th>WATERCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>142</td>\n",
+       "      <td>ASN</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>3.99</td>\n",
+       "      <td>3.24</td>\n",
+       "      <td>170.69</td>\n",
+       "      <td>116.26</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1104</td>\n",
+       "      <td>Nam</td>\n",
+       "      <td>2383</td>\n",
+       "      <td>Npl</td>\n",
+       "      <td>2634</td>\n",
+       "      <td>(3.78, 2.082, 19.566)</td>\n",
+       "      <td>(1.806, -1.075, 19.652)</td>\n",
+       "      <td>(0.07, 1.382, 20.847)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG DIST_A-W  \\\n",
+       "0    142     ASN        A       1101         LIG            A     3.99   \n",
+       "\n",
+       "  DIST_D-W DON_ANGLE WATER_ANGLE  PROTISDON  DONOR_IDX DONORTYPE  \\\n",
+       "0     3.24    170.69      116.26       True       1104       Nam   \n",
+       "\n",
+       "   ACCEPTOR_IDX ACCEPTORTYPE  WATER_IDX                 LIGCOO  \\\n",
+       "0          2383          Npl       2634  (3.78, 2.082, 19.566)   \n",
+       "\n",
+       "                   PROTCOO               WATERCOO  \n",
+       "0  (1.806, -1.075, 19.652)  (0.07, 1.382, 20.847)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hbond"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>SIDECHAIN</th>\n",
+       "      <th>DIST_H-A</th>\n",
+       "      <th>DIST_D-A</th>\n",
+       "      <th>DON_ANGLE</th>\n",
+       "      <th>PROTISDON</th>\n",
+       "      <th>DONORIDX</th>\n",
+       "      <th>DONORTYPE</th>\n",
+       "      <th>ACCEPTORIDX</th>\n",
+       "      <th>ACCEPTORTYPE</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>142</td>\n",
+       "      <td>ASN</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>True</td>\n",
+       "      <td>2.73</td>\n",
+       "      <td>3.53</td>\n",
+       "      <td>139.58</td>\n",
+       "      <td>False</td>\n",
+       "      <td>2383</td>\n",
+       "      <td>Npl</td>\n",
+       "      <td>1110</td>\n",
+       "      <td>O2</td>\n",
+       "      <td>(3.78, 2.082, 19.566)</td>\n",
+       "      <td>(3.045, 0.014, 22.335)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  SIDECHAIN  \\\n",
+       "0    142     ASN        A       1101         LIG            A       True   \n",
+       "\n",
+       "  DIST_H-A DIST_D-A DON_ANGLE  PROTISDON  DONORIDX DONORTYPE  ACCEPTORIDX  \\\n",
+       "0     2.73     3.53    139.58      False      2383       Npl         1110   \n",
+       "\n",
+       "  ACCEPTORTYPE                 LIGCOO                 PROTCOO  \n",
+       "0           O2  (3.78, 2.082, 19.566)  (3.045, 0.014, 22.335)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "# Structure Mpro-x0678.pdb"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Site LIG:A:1101"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hbond"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>SIDECHAIN</th>\n",
+       "      <th>DIST_H-A</th>\n",
+       "      <th>DIST_D-A</th>\n",
+       "      <th>DON_ANGLE</th>\n",
+       "      <th>PROTISDON</th>\n",
+       "      <th>DONORIDX</th>\n",
+       "      <th>DONORTYPE</th>\n",
+       "      <th>ACCEPTORIDX</th>\n",
+       "      <th>ACCEPTORTYPE</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>166</td>\n",
+       "      <td>GLU</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>False</td>\n",
+       "      <td>2.00</td>\n",
+       "      <td>2.97</td>\n",
+       "      <td>168.31</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1288</td>\n",
+       "      <td>Nam</td>\n",
+       "      <td>2398</td>\n",
+       "      <td>O2</td>\n",
+       "      <td>(10.0, 0.972, 20.694)</td>\n",
+       "      <td>(10.388, 2.544, 18.208)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  SIDECHAIN  \\\n",
+       "0    166     GLU        A       1101         LIG            A      False   \n",
+       "\n",
+       "  DIST_H-A DIST_D-A DON_ANGLE  PROTISDON  DONORIDX DONORTYPE  ACCEPTORIDX  \\\n",
+       "0     2.00     2.97    168.31       True      1288       Nam         2398   \n",
+       "\n",
+       "  ACCEPTORTYPE                 LIGCOO                  PROTCOO  \n",
+       "0           O2  (10.0, 0.972, 20.694)  (10.388, 2.544, 18.208)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hydrophobic"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>DIST</th>\n",
+       "      <th>LIGCARBONIDX</th>\n",
+       "      <th>PROTCARBONIDX</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>166</td>\n",
+       "      <td>GLU</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>3.82</td>\n",
+       "      <td>2393</td>\n",
+       "      <td>1292</td>\n",
+       "      <td>(5.662, 1.106, 18.846)</td>\n",
+       "      <td>(8.292, 3.838, 18.353)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>41</td>\n",
+       "      <td>HIS</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>3.93</td>\n",
+       "      <td>2387</td>\n",
+       "      <td>307</td>\n",
+       "      <td>(13.446, -1.874, 22.213)</td>\n",
+       "      <td>(14.064, -5.733, 22.67)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>189</td>\n",
+       "      <td>GLN</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>3.82</td>\n",
+       "      <td>2389</td>\n",
+       "      <td>1468</td>\n",
+       "      <td>(13.497, -0.339, 24.265)</td>\n",
+       "      <td>(13.447, 2.536, 26.776)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>49</td>\n",
+       "      <td>MET</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>3.79</td>\n",
+       "      <td>2389</td>\n",
+       "      <td>368</td>\n",
+       "      <td>(13.497, -0.339, 24.265)</td>\n",
+       "      <td>(12.993, -1.667, 27.783)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  DIST  \\\n",
+       "0    166     GLU        A       1101         LIG            A  3.82   \n",
+       "1     41     HIS        A       1101         LIG            A  3.93   \n",
+       "2    189     GLN        A       1101         LIG            A  3.82   \n",
+       "3     49     MET        A       1101         LIG            A  3.79   \n",
+       "\n",
+       "   LIGCARBONIDX  PROTCARBONIDX                    LIGCOO  \\\n",
+       "0          2393           1292    (5.662, 1.106, 18.846)   \n",
+       "1          2387            307  (13.446, -1.874, 22.213)   \n",
+       "2          2389           1468  (13.497, -0.339, 24.265)   \n",
+       "3          2389            368  (13.497, -0.339, 24.265)   \n",
+       "\n",
+       "                    PROTCOO  \n",
+       "0    (8.292, 3.838, 18.353)  \n",
+       "1   (14.064, -5.733, 22.67)  \n",
+       "2   (13.447, 2.536, 26.776)  \n",
+       "3  (12.993, -1.667, 27.783)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "# Structure Mpro-x0991.pdb"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Site LIG:A:1101"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hbond"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>SIDECHAIN</th>\n",
+       "      <th>DIST_H-A</th>\n",
+       "      <th>DIST_D-A</th>\n",
+       "      <th>DON_ANGLE</th>\n",
+       "      <th>PROTISDON</th>\n",
+       "      <th>DONORIDX</th>\n",
+       "      <th>DONORTYPE</th>\n",
+       "      <th>ACCEPTORIDX</th>\n",
+       "      <th>ACCEPTORTYPE</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>25</td>\n",
+       "      <td>THR</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>True</td>\n",
+       "      <td>3.53</td>\n",
+       "      <td>3.91</td>\n",
+       "      <td>106.27</td>\n",
+       "      <td>True</td>\n",
+       "      <td>178</td>\n",
+       "      <td>O3</td>\n",
+       "      <td>2387</td>\n",
+       "      <td>Ng+</td>\n",
+       "      <td>(8.523, -4.964, 26.462)</td>\n",
+       "      <td>(7.873, -8.788, 26.952)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>45</td>\n",
+       "      <td>THR</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>False</td>\n",
+       "      <td>3.20</td>\n",
+       "      <td>4.09</td>\n",
+       "      <td>150.78</td>\n",
+       "      <td>False</td>\n",
+       "      <td>2387</td>\n",
+       "      <td>Ng+</td>\n",
+       "      <td>337</td>\n",
+       "      <td>O2</td>\n",
+       "      <td>(8.523, -4.964, 26.462)</td>\n",
+       "      <td>(11.093, -4.54, 29.613)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>41</td>\n",
+       "      <td>HIS</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>False</td>\n",
+       "      <td>2.29</td>\n",
+       "      <td>2.71</td>\n",
+       "      <td>104.83</td>\n",
+       "      <td>False</td>\n",
+       "      <td>2383</td>\n",
+       "      <td>Ng+</td>\n",
+       "      <td>306</td>\n",
+       "      <td>O2</td>\n",
+       "      <td>(10.203, -5.727, 25.115)</td>\n",
+       "      <td>(12.032, -7.656, 24.576)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  SIDECHAIN  \\\n",
+       "0     25     THR        A       1101         LIG            A       True   \n",
+       "1     45     THR        A       1101         LIG            A      False   \n",
+       "2     41     HIS        A       1101         LIG            A      False   \n",
+       "\n",
+       "  DIST_H-A DIST_D-A DON_ANGLE  PROTISDON  DONORIDX DONORTYPE  ACCEPTORIDX  \\\n",
+       "0     3.53     3.91    106.27       True       178        O3         2387   \n",
+       "1     3.20     4.09    150.78      False      2387       Ng+          337   \n",
+       "2     2.29     2.71    104.83      False      2383       Ng+          306   \n",
+       "\n",
+       "  ACCEPTORTYPE                    LIGCOO                   PROTCOO  \n",
+       "0          Ng+   (8.523, -4.964, 26.462)   (7.873, -8.788, 26.952)  \n",
+       "1           O2   (8.523, -4.964, 26.462)   (11.093, -4.54, 29.613)  \n",
+       "2           O2  (10.203, -5.727, 25.115)  (12.032, -7.656, 24.576)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hydrophobic"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>DIST</th>\n",
+       "      <th>LIGCARBONIDX</th>\n",
+       "      <th>PROTCARBONIDX</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>25</td>\n",
+       "      <td>THR</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>3.96</td>\n",
+       "      <td>2385</td>\n",
+       "      <td>179</td>\n",
+       "      <td>(8.148, -4.725, 24.034)</td>\n",
+       "      <td>(7.746, -8.624, 24.575)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  DIST  \\\n",
+       "0     25     THR        A       1101         LIG            A  3.96   \n",
+       "\n",
+       "   LIGCARBONIDX  PROTCARBONIDX                   LIGCOO  \\\n",
+       "0          2385            179  (8.148, -4.725, 24.034)   \n",
+       "\n",
+       "                   PROTCOO  \n",
+       "0  (7.746, -8.624, 24.575)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "# Structure Mpro-x0305.pdb"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Site LIG:A:1101"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### waterbridge"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>DIST_A-W</th>\n",
+       "      <th>DIST_D-W</th>\n",
+       "      <th>DON_ANGLE</th>\n",
+       "      <th>WATER_ANGLE</th>\n",
+       "      <th>PROTISDON</th>\n",
+       "      <th>DONOR_IDX</th>\n",
+       "      <th>DONORTYPE</th>\n",
+       "      <th>ACCEPTOR_IDX</th>\n",
+       "      <th>ACCEPTORTYPE</th>\n",
+       "      <th>WATER_IDX</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "      <th>WATERCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>164</td>\n",
+       "      <td>HIS</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>4.02</td>\n",
+       "      <td>2.88</td>\n",
+       "      <td>142.75</td>\n",
+       "      <td>116.95</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1276</td>\n",
+       "      <td>Nar</td>\n",
+       "      <td>2392</td>\n",
+       "      <td>N1</td>\n",
+       "      <td>2400</td>\n",
+       "      <td>(14.122, -1.82, 20.508)</td>\n",
+       "      <td>(15.081, -4.706, 17.493)</td>\n",
+       "      <td>(15.605, -5.539, 20.201)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG DIST_A-W  \\\n",
+       "0    164     HIS        A       1101         LIG            A     4.02   \n",
+       "\n",
+       "  DIST_D-W DON_ANGLE WATER_ANGLE  PROTISDON  DONOR_IDX DONORTYPE  \\\n",
+       "0     2.88    142.75      116.95       True       1276       Nar   \n",
+       "\n",
+       "   ACCEPTOR_IDX ACCEPTORTYPE  WATER_IDX                   LIGCOO  \\\n",
+       "0          2392           N1       2400  (14.122, -1.82, 20.508)   \n",
+       "\n",
+       "                    PROTCOO                  WATERCOO  \n",
+       "0  (15.081, -4.706, 17.493)  (15.605, -5.539, 20.201)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hbond"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>SIDECHAIN</th>\n",
+       "      <th>DIST_H-A</th>\n",
+       "      <th>DIST_D-A</th>\n",
+       "      <th>DON_ANGLE</th>\n",
+       "      <th>PROTISDON</th>\n",
+       "      <th>DONORIDX</th>\n",
+       "      <th>DONORTYPE</th>\n",
+       "      <th>ACCEPTORIDX</th>\n",
+       "      <th>ACCEPTORTYPE</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>41</td>\n",
+       "      <td>HIS</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>True</td>\n",
+       "      <td>2.48</td>\n",
+       "      <td>3.11</td>\n",
+       "      <td>121.14</td>\n",
+       "      <td>True</td>\n",
+       "      <td>309</td>\n",
+       "      <td>Nar</td>\n",
+       "      <td>2392</td>\n",
+       "      <td>N1</td>\n",
+       "      <td>(14.122, -1.82, 20.508)</td>\n",
+       "      <td>(12.877, -4.624, 21.017)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>189</td>\n",
+       "      <td>GLN</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>True</td>\n",
+       "      <td>2.37</td>\n",
+       "      <td>3.16</td>\n",
+       "      <td>136.75</td>\n",
+       "      <td>False</td>\n",
+       "      <td>2391</td>\n",
+       "      <td>Npl</td>\n",
+       "      <td>1471</td>\n",
+       "      <td>O2</td>\n",
+       "      <td>(10.162, 0.163, 25.71)</td>\n",
+       "      <td>(10.373, 1.776, 28.414)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  SIDECHAIN  \\\n",
+       "0     41     HIS        A       1101         LIG            A       True   \n",
+       "1    189     GLN        A       1101         LIG            A       True   \n",
+       "\n",
+       "  DIST_H-A DIST_D-A DON_ANGLE  PROTISDON  DONORIDX DONORTYPE  ACCEPTORIDX  \\\n",
+       "0     2.48     3.11    121.14       True       309       Nar         2392   \n",
+       "1     2.37     3.16    136.75      False      2391       Npl         1471   \n",
+       "\n",
+       "  ACCEPTORTYPE                   LIGCOO                   PROTCOO  \n",
+       "0           N1  (14.122, -1.82, 20.508)  (12.877, -4.624, 21.017)  \n",
+       "1           O2   (10.162, 0.163, 25.71)   (10.373, 1.776, 28.414)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### pistacking"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>CENTDIST</th>\n",
+       "      <th>ANGLE</th>\n",
+       "      <th>OFFSET</th>\n",
+       "      <th>TYPE</th>\n",
+       "      <th>LIG_IDX_LIST</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>41</td>\n",
+       "      <td>HIS</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>4.88</td>\n",
+       "      <td>77.20</td>\n",
+       "      <td>0.62</td>\n",
+       "      <td>T</td>\n",
+       "      <td>2385,2386,2387,2388,2390,2393</td>\n",
+       "      <td>(11.750833333333334, -0.6871666666666666, 23.5...</td>\n",
+       "      <td>(11.877, -5.0280000000000005, 21.3542)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG CENTDIST  ANGLE  \\\n",
+       "0     41     HIS        A       1101         LIG            A     4.88  77.20   \n",
+       "\n",
+       "  OFFSET TYPE                   LIG_IDX_LIST  \\\n",
+       "0   0.62    T  2385,2386,2387,2388,2390,2393   \n",
+       "\n",
+       "                                              LIGCOO  \\\n",
+       "0  (11.750833333333334, -0.6871666666666666, 23.5...   \n",
+       "\n",
+       "                                  PROTCOO  \n",
+       "0  (11.877, -5.0280000000000005, 21.3542)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "# Structure Mpro-x0540.pdb"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Site LIG:A:1101"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### waterbridge"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>DIST_A-W</th>\n",
+       "      <th>DIST_D-W</th>\n",
+       "      <th>DON_ANGLE</th>\n",
+       "      <th>WATER_ANGLE</th>\n",
+       "      <th>PROTISDON</th>\n",
+       "      <th>DONOR_IDX</th>\n",
+       "      <th>DONORTYPE</th>\n",
+       "      <th>ACCEPTOR_IDX</th>\n",
+       "      <th>ACCEPTORTYPE</th>\n",
+       "      <th>WATER_IDX</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "      <th>WATERCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>166</td>\n",
+       "      <td>GLU</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>3.50</td>\n",
+       "      <td>3.83</td>\n",
+       "      <td>141.78</td>\n",
+       "      <td>102.95</td>\n",
+       "      <td>False</td>\n",
+       "      <td>2399</td>\n",
+       "      <td>Nam</td>\n",
+       "      <td>1295</td>\n",
+       "      <td>O3</td>\n",
+       "      <td>2556</td>\n",
+       "      <td>(2.294, 3.164, 23.244)</td>\n",
+       "      <td>(4.854, 4.81, 19.435)</td>\n",
+       "      <td>(1.389, 4.396, 19.734)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG DIST_A-W  \\\n",
+       "0    166     GLU        A       1101         LIG            A     3.50   \n",
+       "\n",
+       "  DIST_D-W DON_ANGLE WATER_ANGLE  PROTISDON  DONOR_IDX DONORTYPE  \\\n",
+       "0     3.83    141.78      102.95      False       2399       Nam   \n",
+       "\n",
+       "   ACCEPTOR_IDX ACCEPTORTYPE  WATER_IDX                  LIGCOO  \\\n",
+       "0          1295           O3       2556  (2.294, 3.164, 23.244)   \n",
+       "\n",
+       "                 PROTCOO                WATERCOO  \n",
+       "0  (4.854, 4.81, 19.435)  (1.389, 4.396, 19.734)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hbond"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>SIDECHAIN</th>\n",
+       "      <th>DIST_H-A</th>\n",
+       "      <th>DIST_D-A</th>\n",
+       "      <th>DON_ANGLE</th>\n",
+       "      <th>PROTISDON</th>\n",
+       "      <th>DONORIDX</th>\n",
+       "      <th>DONORTYPE</th>\n",
+       "      <th>ACCEPTORIDX</th>\n",
+       "      <th>ACCEPTORTYPE</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>142</td>\n",
+       "      <td>ASN</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>True</td>\n",
+       "      <td>2.57</td>\n",
+       "      <td>3.04</td>\n",
+       "      <td>108.86</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1111</td>\n",
+       "      <td>Nam</td>\n",
+       "      <td>2400</td>\n",
+       "      <td>O2</td>\n",
+       "      <td>(3.33, 1.358, 24.276)</td>\n",
+       "      <td>(2.686, -1.609, 24.166)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>166</td>\n",
+       "      <td>GLU</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>True</td>\n",
+       "      <td>3.46</td>\n",
+       "      <td>3.98</td>\n",
+       "      <td>117.82</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1295</td>\n",
+       "      <td>O3</td>\n",
+       "      <td>2397</td>\n",
+       "      <td>Nam</td>\n",
+       "      <td>(4.501, 2.341, 22.538)</td>\n",
+       "      <td>(4.854, 4.81, 19.435)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>166</td>\n",
+       "      <td>GLU</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>True</td>\n",
+       "      <td>3.02</td>\n",
+       "      <td>3.98</td>\n",
+       "      <td>166.54</td>\n",
+       "      <td>False</td>\n",
+       "      <td>2397</td>\n",
+       "      <td>Nam</td>\n",
+       "      <td>1295</td>\n",
+       "      <td>O3</td>\n",
+       "      <td>(4.501, 2.341, 22.538)</td>\n",
+       "      <td>(4.854, 4.81, 19.435)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  SIDECHAIN  \\\n",
+       "0    142     ASN        A       1101         LIG            A       True   \n",
+       "1    166     GLU        A       1101         LIG            A       True   \n",
+       "2    166     GLU        A       1101         LIG            A       True   \n",
+       "\n",
+       "  DIST_H-A DIST_D-A DON_ANGLE  PROTISDON  DONORIDX DONORTYPE  ACCEPTORIDX  \\\n",
+       "0     2.57     3.04    108.86       True      1111       Nam         2400   \n",
+       "1     3.46     3.98    117.82       True      1295        O3         2397   \n",
+       "2     3.02     3.98    166.54      False      2397       Nam         1295   \n",
+       "\n",
+       "  ACCEPTORTYPE                  LIGCOO                  PROTCOO  \n",
+       "0           O2   (3.33, 1.358, 24.276)  (2.686, -1.609, 24.166)  \n",
+       "1          Nam  (4.501, 2.341, 22.538)    (4.854, 4.81, 19.435)  \n",
+       "2           O3  (4.501, 2.341, 22.538)    (4.854, 4.81, 19.435)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hydrophobic"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>DIST</th>\n",
+       "      <th>LIGCARBONIDX</th>\n",
+       "      <th>PROTCARBONIDX</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>166</td>\n",
+       "      <td>GLU</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>3.90</td>\n",
+       "      <td>2390</td>\n",
+       "      <td>1292</td>\n",
+       "      <td>(5.02, 1.202, 19.424)</td>\n",
+       "      <td>(7.898, 3.809, 19.075)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  DIST  \\\n",
+       "0    166     GLU        A       1101         LIG            A  3.90   \n",
+       "\n",
+       "   LIGCARBONIDX  PROTCARBONIDX                 LIGCOO                 PROTCOO  \n",
+       "0          2390           1292  (5.02, 1.202, 19.424)  (7.898, 3.809, 19.075)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "# Structure Mpro-x0195.pdb"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Site LIG:A:801"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hbond"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>SIDECHAIN</th>\n",
+       "      <th>DIST_H-A</th>\n",
+       "      <th>DIST_D-A</th>\n",
+       "      <th>DON_ANGLE</th>\n",
+       "      <th>PROTISDON</th>\n",
+       "      <th>DONORIDX</th>\n",
+       "      <th>DONORTYPE</th>\n",
+       "      <th>ACCEPTORIDX</th>\n",
+       "      <th>ACCEPTORTYPE</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>190</td>\n",
+       "      <td>THR</td>\n",
+       "      <td>A</td>\n",
+       "      <td>801</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>False</td>\n",
+       "      <td>2.97</td>\n",
+       "      <td>3.85</td>\n",
+       "      <td>144.47</td>\n",
+       "      <td>False</td>\n",
+       "      <td>2394</td>\n",
+       "      <td>N3</td>\n",
+       "      <td>1476</td>\n",
+       "      <td>O2</td>\n",
+       "      <td>(12.368, 6.143, 23.209)</td>\n",
+       "      <td>(15.917, 7.208, 24.257)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  SIDECHAIN  \\\n",
+       "0    190     THR        A        801         LIG            A      False   \n",
+       "\n",
+       "  DIST_H-A DIST_D-A DON_ANGLE  PROTISDON  DONORIDX DONORTYPE  ACCEPTORIDX  \\\n",
+       "0     2.97     3.85    144.47      False      2394        N3         1476   \n",
+       "\n",
+       "  ACCEPTORTYPE                   LIGCOO                  PROTCOO  \n",
+       "0           O2  (12.368, 6.143, 23.209)  (15.917, 7.208, 24.257)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hydrophobic"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>DIST</th>\n",
+       "      <th>LIGCARBONIDX</th>\n",
+       "      <th>PROTCARBONIDX</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>189</td>\n",
+       "      <td>GLN</td>\n",
+       "      <td>A</td>\n",
+       "      <td>801</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>3.71</td>\n",
+       "      <td>2391</td>\n",
+       "      <td>1468</td>\n",
+       "      <td>(11.761, 2.061, 23.574)</td>\n",
+       "      <td>(13.71, 2.3, 26.72)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>165</td>\n",
+       "      <td>MET</td>\n",
+       "      <td>A</td>\n",
+       "      <td>801</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>3.76</td>\n",
+       "      <td>2387</td>\n",
+       "      <td>1284</td>\n",
+       "      <td>(13.7, 0.904, 22.706)</td>\n",
+       "      <td>(12.46, 0.984, 19.16)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  DIST  \\\n",
+       "0    189     GLN        A        801         LIG            A  3.71   \n",
+       "1    165     MET        A        801         LIG            A  3.76   \n",
+       "\n",
+       "   LIGCARBONIDX  PROTCARBONIDX                   LIGCOO                PROTCOO  \n",
+       "0          2391           1468  (11.761, 2.061, 23.574)    (13.71, 2.3, 26.72)  \n",
+       "1          2387           1284    (13.7, 0.904, 22.706)  (12.46, 0.984, 19.16)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "# Structure Mpro-x0434.pdb"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Site LIG:A:1101"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hbond"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>SIDECHAIN</th>\n",
+       "      <th>DIST_H-A</th>\n",
+       "      <th>DIST_D-A</th>\n",
+       "      <th>DON_ANGLE</th>\n",
+       "      <th>PROTISDON</th>\n",
+       "      <th>DONORIDX</th>\n",
+       "      <th>DONORTYPE</th>\n",
+       "      <th>ACCEPTORIDX</th>\n",
+       "      <th>ACCEPTORTYPE</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>166</td>\n",
+       "      <td>GLU</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>False</td>\n",
+       "      <td>2.06</td>\n",
+       "      <td>3.00</td>\n",
+       "      <td>160.71</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1288</td>\n",
+       "      <td>Nam</td>\n",
+       "      <td>2398</td>\n",
+       "      <td>O2</td>\n",
+       "      <td>(9.192, 0.679, 20.85)</td>\n",
+       "      <td>(9.816, 2.578, 18.607)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>142</td>\n",
+       "      <td>ASN</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>True</td>\n",
+       "      <td>3.22</td>\n",
+       "      <td>3.82</td>\n",
+       "      <td>121.61</td>\n",
+       "      <td>False</td>\n",
+       "      <td>2396</td>\n",
+       "      <td>Nam</td>\n",
+       "      <td>1110</td>\n",
+       "      <td>O2</td>\n",
+       "      <td>(7.33, -0.662, 20.931)</td>\n",
+       "      <td>(4.21, -1.088, 23.102)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  SIDECHAIN  \\\n",
+       "0    166     GLU        A       1101         LIG            A      False   \n",
+       "1    142     ASN        A       1101         LIG            A       True   \n",
+       "\n",
+       "  DIST_H-A DIST_D-A DON_ANGLE  PROTISDON  DONORIDX DONORTYPE  ACCEPTORIDX  \\\n",
+       "0     2.06     3.00    160.71       True      1288       Nam         2398   \n",
+       "1     3.22     3.82    121.61      False      2396       Nam         1110   \n",
+       "\n",
+       "  ACCEPTORTYPE                  LIGCOO                 PROTCOO  \n",
+       "0           O2   (9.192, 0.679, 20.85)  (9.816, 2.578, 18.607)  \n",
+       "1           O2  (7.33, -0.662, 20.931)  (4.21, -1.088, 23.102)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### pistacking"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>CENTDIST</th>\n",
+       "      <th>ANGLE</th>\n",
+       "      <th>OFFSET</th>\n",
+       "      <th>TYPE</th>\n",
+       "      <th>LIG_IDX_LIST</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>41</td>\n",
+       "      <td>HIS</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>5.20</td>\n",
+       "      <td>71.19</td>\n",
+       "      <td>1.60</td>\n",
+       "      <td>T</td>\n",
+       "      <td>2384,2385,2386,2387,2388,2389</td>\n",
+       "      <td>(11.763666666666667, 0.01999999999999998, 23.2...</td>\n",
+       "      <td>(11.7332, -4.842599999999999, 21.3876)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG CENTDIST  ANGLE  \\\n",
+       "0     41     HIS        A       1101         LIG            A     5.20  71.19   \n",
+       "\n",
+       "  OFFSET TYPE                   LIG_IDX_LIST  \\\n",
+       "0   1.60    T  2384,2385,2386,2387,2388,2389   \n",
+       "\n",
+       "                                              LIGCOO  \\\n",
+       "0  (11.763666666666667, 0.01999999999999998, 23.2...   \n",
+       "\n",
+       "                                  PROTCOO  \n",
+       "0  (11.7332, -4.842599999999999, 21.3876)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hydrophobic"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>DIST</th>\n",
+       "      <th>LIGCARBONIDX</th>\n",
+       "      <th>PROTCARBONIDX</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>166</td>\n",
+       "      <td>GLU</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>3.99</td>\n",
+       "      <td>2392</td>\n",
+       "      <td>1292</td>\n",
+       "      <td>(4.815, 1.312, 19.109)</td>\n",
+       "      <td>(7.757, 3.972, 18.67)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>189</td>\n",
+       "      <td>GLN</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>3.59</td>\n",
+       "      <td>2386</td>\n",
+       "      <td>1468</td>\n",
+       "      <td>(11.811, 0.848, 24.344)</td>\n",
+       "      <td>(12.84, 2.528, 27.347)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  DIST  \\\n",
+       "0    166     GLU        A       1101         LIG            A  3.99   \n",
+       "1    189     GLN        A       1101         LIG            A  3.59   \n",
+       "\n",
+       "   LIGCARBONIDX  PROTCARBONIDX                   LIGCOO  \\\n",
+       "0          2392           1292   (4.815, 1.312, 19.109)   \n",
+       "1          2386           1468  (11.811, 0.848, 24.344)   \n",
+       "\n",
+       "                  PROTCOO  \n",
+       "0   (7.757, 3.972, 18.67)  \n",
+       "1  (12.84, 2.528, 27.347)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "# Structure Mpro-x0387.pdb"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Site LIG:A:1101"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### pistacking"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>CENTDIST</th>\n",
+       "      <th>ANGLE</th>\n",
+       "      <th>OFFSET</th>\n",
+       "      <th>TYPE</th>\n",
+       "      <th>LIG_IDX_LIST</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>41</td>\n",
+       "      <td>HIS</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>4.60</td>\n",
+       "      <td>72.90</td>\n",
+       "      <td>1.44</td>\n",
+       "      <td>T</td>\n",
+       "      <td>2387,2388,2389,2390,2395</td>\n",
+       "      <td>(12.3836, -0.9454, 23.1674)</td>\n",
+       "      <td>(11.9174, -5.1104, 21.279199999999996)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG CENTDIST  ANGLE  \\\n",
+       "0     41     HIS        A       1101         LIG            A     4.60  72.90   \n",
+       "\n",
+       "  OFFSET TYPE              LIG_IDX_LIST                       LIGCOO  \\\n",
+       "0   1.44    T  2387,2388,2389,2390,2395  (12.3836, -0.9454, 23.1674)   \n",
+       "\n",
+       "                                  PROTCOO  \n",
+       "0  (11.9174, -5.1104, 21.279199999999996)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "# Structure Mpro-x0874.pdb"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Site LIG:A:1101"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hbond"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>SIDECHAIN</th>\n",
+       "      <th>DIST_H-A</th>\n",
+       "      <th>DIST_D-A</th>\n",
+       "      <th>DON_ANGLE</th>\n",
+       "      <th>PROTISDON</th>\n",
+       "      <th>DONORIDX</th>\n",
+       "      <th>DONORTYPE</th>\n",
+       "      <th>ACCEPTORIDX</th>\n",
+       "      <th>ACCEPTORTYPE</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>166</td>\n",
+       "      <td>GLU</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>False</td>\n",
+       "      <td>2.01</td>\n",
+       "      <td>2.99</td>\n",
+       "      <td>177.99</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1288</td>\n",
+       "      <td>Nam</td>\n",
+       "      <td>2394</td>\n",
+       "      <td>O2</td>\n",
+       "      <td>(9.329, 1.303, 21.126)</td>\n",
+       "      <td>(9.997, 2.593, 18.511)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>166</td>\n",
+       "      <td>GLU</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>False</td>\n",
+       "      <td>1.75</td>\n",
+       "      <td>2.62</td>\n",
+       "      <td>145.86</td>\n",
+       "      <td>False</td>\n",
+       "      <td>2393</td>\n",
+       "      <td>Nam</td>\n",
+       "      <td>1291</td>\n",
+       "      <td>O2</td>\n",
+       "      <td>(10.468, 3.035, 22.181)</td>\n",
+       "      <td>(10.354, 4.748, 20.197)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  SIDECHAIN  \\\n",
+       "0    166     GLU        A       1101         LIG            A      False   \n",
+       "1    166     GLU        A       1101         LIG            A      False   \n",
+       "\n",
+       "  DIST_H-A DIST_D-A DON_ANGLE  PROTISDON  DONORIDX DONORTYPE  ACCEPTORIDX  \\\n",
+       "0     2.01     2.99    177.99       True      1288       Nam         2394   \n",
+       "1     1.75     2.62    145.86      False      2393       Nam         1291   \n",
+       "\n",
+       "  ACCEPTORTYPE                   LIGCOO                  PROTCOO  \n",
+       "0           O2   (9.329, 1.303, 21.126)   (9.997, 2.593, 18.511)  \n",
+       "1           O2  (10.468, 3.035, 22.181)  (10.354, 4.748, 20.197)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### pistacking"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>CENTDIST</th>\n",
+       "      <th>ANGLE</th>\n",
+       "      <th>OFFSET</th>\n",
+       "      <th>TYPE</th>\n",
+       "      <th>LIG_IDX_LIST</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>41</td>\n",
+       "      <td>HIS</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>4.72</td>\n",
+       "      <td>81.00</td>\n",
+       "      <td>1.68</td>\n",
+       "      <td>T</td>\n",
+       "      <td>2389,2390,2391,2392,2395</td>\n",
+       "      <td>(12.423599999999999, -0.53, 22.5898)</td>\n",
+       "      <td>(11.9448, -5.0318000000000005, 21.2454)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG CENTDIST  ANGLE  \\\n",
+       "0     41     HIS        A       1101         LIG            A     4.72  81.00   \n",
+       "\n",
+       "  OFFSET TYPE              LIG_IDX_LIST                                LIGCOO  \\\n",
+       "0   1.68    T  2389,2390,2391,2392,2395  (12.423599999999999, -0.53, 22.5898)   \n",
+       "\n",
+       "                                   PROTCOO  \n",
+       "0  (11.9448, -5.0318000000000005, 21.2454)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "# Structure Mpro-x1249.pdb"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Site LIG:A:1101"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### waterbridge"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>DIST_A-W</th>\n",
+       "      <th>DIST_D-W</th>\n",
+       "      <th>DON_ANGLE</th>\n",
+       "      <th>WATER_ANGLE</th>\n",
+       "      <th>PROTISDON</th>\n",
+       "      <th>DONOR_IDX</th>\n",
+       "      <th>DONORTYPE</th>\n",
+       "      <th>ACCEPTOR_IDX</th>\n",
+       "      <th>ACCEPTORTYPE</th>\n",
+       "      <th>WATER_IDX</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "      <th>WATERCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>164</td>\n",
+       "      <td>HIS</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>4.10</td>\n",
+       "      <td>2.87</td>\n",
+       "      <td>138.43</td>\n",
+       "      <td>120.06</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1290</td>\n",
+       "      <td>Nar</td>\n",
+       "      <td>2444</td>\n",
+       "      <td>N1</td>\n",
+       "      <td>2453</td>\n",
+       "      <td>(14.061, -1.841, 20.54)</td>\n",
+       "      <td>(15.054, -4.686, 17.535)</td>\n",
+       "      <td>(15.594, -5.624, 20.196)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG DIST_A-W  \\\n",
+       "0    164     HIS        A       1101         LIG            A     4.10   \n",
+       "\n",
+       "  DIST_D-W DON_ANGLE WATER_ANGLE  PROTISDON  DONOR_IDX DONORTYPE  \\\n",
+       "0     2.87    138.43      120.06       True       1290       Nar   \n",
+       "\n",
+       "   ACCEPTOR_IDX ACCEPTORTYPE  WATER_IDX                   LIGCOO  \\\n",
+       "0          2444           N1       2453  (14.061, -1.841, 20.54)   \n",
+       "\n",
+       "                    PROTCOO                  WATERCOO  \n",
+       "0  (15.054, -4.686, 17.535)  (15.594, -5.624, 20.196)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hbond"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>SIDECHAIN</th>\n",
+       "      <th>DIST_H-A</th>\n",
+       "      <th>DIST_D-A</th>\n",
+       "      <th>DON_ANGLE</th>\n",
+       "      <th>PROTISDON</th>\n",
+       "      <th>DONORIDX</th>\n",
+       "      <th>DONORTYPE</th>\n",
+       "      <th>ACCEPTORIDX</th>\n",
+       "      <th>ACCEPTORTYPE</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>41</td>\n",
+       "      <td>HIS</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>True</td>\n",
+       "      <td>2.44</td>\n",
+       "      <td>3.08</td>\n",
+       "      <td>122.60</td>\n",
+       "      <td>True</td>\n",
+       "      <td>309</td>\n",
+       "      <td>Nar</td>\n",
+       "      <td>2444</td>\n",
+       "      <td>N1</td>\n",
+       "      <td>(14.061, -1.841, 20.54)</td>\n",
+       "      <td>(12.794, -4.607, 21.042)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  SIDECHAIN  \\\n",
+       "0     41     HIS        A       1101         LIG            A       True   \n",
+       "\n",
+       "  DIST_H-A DIST_D-A DON_ANGLE  PROTISDON  DONORIDX DONORTYPE  ACCEPTORIDX  \\\n",
+       "0     2.44     3.08    122.60       True       309       Nar         2444   \n",
+       "\n",
+       "  ACCEPTORTYPE                   LIGCOO                   PROTCOO  \n",
+       "0           N1  (14.061, -1.841, 20.54)  (12.794, -4.607, 21.042)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### pistacking"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>CENTDIST</th>\n",
+       "      <th>ANGLE</th>\n",
+       "      <th>OFFSET</th>\n",
+       "      <th>TYPE</th>\n",
+       "      <th>LIG_IDX_LIST</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>41</td>\n",
+       "      <td>HIS</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>5.14</td>\n",
+       "      <td>87.37</td>\n",
+       "      <td>1.26</td>\n",
+       "      <td>T</td>\n",
+       "      <td>2436,2437,2438,2439,2441,2442</td>\n",
+       "      <td>(11.690833333333332, -0.2608333333333333, 23.2...</td>\n",
+       "      <td>(11.795599999999999, -5.0338, 21.373)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG CENTDIST  ANGLE  \\\n",
+       "0     41     HIS        A       1101         LIG            A     5.14  87.37   \n",
+       "\n",
+       "  OFFSET TYPE                   LIG_IDX_LIST  \\\n",
+       "0   1.26    T  2436,2437,2438,2439,2441,2442   \n",
+       "\n",
+       "                                              LIGCOO  \\\n",
+       "0  (11.690833333333332, -0.2608333333333333, 23.2...   \n",
+       "\n",
+       "                                 PROTCOO  \n",
+       "0  (11.795599999999999, -5.0338, 21.373)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### hydrophobic"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RESNR</th>\n",
+       "      <th>RESTYPE</th>\n",
+       "      <th>RESCHAIN</th>\n",
+       "      <th>RESNR_LIG</th>\n",
+       "      <th>RESTYPE_LIG</th>\n",
+       "      <th>RESCHAIN_LIG</th>\n",
+       "      <th>DIST</th>\n",
+       "      <th>LIGCARBONIDX</th>\n",
+       "      <th>PROTCARBONIDX</th>\n",
+       "      <th>LIGCOO</th>\n",
+       "      <th>PROTCOO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>189</td>\n",
+       "      <td>GLN</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>3.85</td>\n",
+       "      <td>2437</td>\n",
+       "      <td>1482</td>\n",
+       "      <td>(12.014, 0.979, 23.834)</td>\n",
+       "      <td>(12.876, 2.521, 27.25)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  DIST  \\\n",
+       "0    189     GLN        A       1101         LIG            A  3.85   \n",
+       "\n",
+       "   LIGCARBONIDX  PROTCARBONIDX                   LIGCOO  \\\n",
+       "0          2437           1482  (12.014, 0.979, 23.834)   \n",
+       "\n",
+       "                  PROTCOO  \n",
+       "0  (12.876, 2.521, 27.25)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "for structure, sites in interactions.items():\n",
+    "    display(Markdown(\"# Structure {}\".format(structure)))\n",
+    "    for site_name, site_interactions in sites.items():\n",
+    "        if not site_name.startswith('LIG'):\n",
+    "            continue  # fragments are labeled as LIG; other \"sites\" detected by PLIP are XRC artefacts\n",
+    "        display(Markdown(\"## Site {}\".format(site_name)))\n",
+    "        for interaction_type, dataframe in site_to_dataframes(site_interactions).items():\n",
+    "            if dataframe is not None:\n",
+    "                display(Markdown(\"### {}\".format(interaction_type)))\n",
+    "                display(dataframe)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/C-plip-fingerprints/C-plip-fingerprints.ipynb
+++ b/C-plip-fingerprints/C-plip-fingerprints.ipynb
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,7 +29,8 @@
     "import pandas as pd\n",
     "from tqdm.notebook import tqdm\n",
     "from plip.modules.preparation import PDBComplex\n",
-    "from plip.modules.report import BindingSiteReport"
+    "from plip.modules.report import BindingSiteReport\n",
+    "import nglview as nv"
    ]
   },
   {
@@ -41,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,13 +103,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "18de10186f4e4823b54edb895415243a",
+       "model_id": "a5b4c45619a64192a025a426d9d9dccf",
        "version_major": 2,
        "version_minor": 0
       },
@@ -142,9 +143,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 6,
    "metadata": {
-    "scrolled": false
+    "scrolled": true
    },
    "outputs": [
     {
@@ -3836,26 +3837,6 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>142</td>\n",
-       "      <td>ASN</td>\n",
-       "      <td>A</td>\n",
-       "      <td>1101</td>\n",
-       "      <td>LIG</td>\n",
-       "      <td>A</td>\n",
-       "      <td>True</td>\n",
-       "      <td>2.57</td>\n",
-       "      <td>3.04</td>\n",
-       "      <td>108.86</td>\n",
-       "      <td>True</td>\n",
-       "      <td>1111</td>\n",
-       "      <td>Nam</td>\n",
-       "      <td>2400</td>\n",
-       "      <td>O2</td>\n",
-       "      <td>(3.33, 1.358, 24.276)</td>\n",
-       "      <td>(2.686, -1.609, 24.166)</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
        "      <td>166</td>\n",
        "      <td>GLU</td>\n",
        "      <td>A</td>\n",
@@ -3873,6 +3854,26 @@
        "      <td>Nam</td>\n",
        "      <td>(4.501, 2.341, 22.538)</td>\n",
        "      <td>(4.854, 4.81, 19.435)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>142</td>\n",
+       "      <td>ASN</td>\n",
+       "      <td>A</td>\n",
+       "      <td>1101</td>\n",
+       "      <td>LIG</td>\n",
+       "      <td>A</td>\n",
+       "      <td>True</td>\n",
+       "      <td>2.57</td>\n",
+       "      <td>3.04</td>\n",
+       "      <td>108.86</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1111</td>\n",
+       "      <td>Nam</td>\n",
+       "      <td>2400</td>\n",
+       "      <td>O2</td>\n",
+       "      <td>(3.33, 1.358, 24.276)</td>\n",
+       "      <td>(2.686, -1.609, 24.166)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
@@ -3900,18 +3901,18 @@
       ],
       "text/plain": [
        "   RESNR RESTYPE RESCHAIN  RESNR_LIG RESTYPE_LIG RESCHAIN_LIG  SIDECHAIN  \\\n",
-       "0    142     ASN        A       1101         LIG            A       True   \n",
-       "1    166     GLU        A       1101         LIG            A       True   \n",
+       "0    166     GLU        A       1101         LIG            A       True   \n",
+       "1    142     ASN        A       1101         LIG            A       True   \n",
        "2    166     GLU        A       1101         LIG            A       True   \n",
        "\n",
        "  DIST_H-A DIST_D-A DON_ANGLE  PROTISDON  DONORIDX DONORTYPE  ACCEPTORIDX  \\\n",
-       "0     2.57     3.04    108.86       True      1111       Nam         2400   \n",
-       "1     3.46     3.98    117.82       True      1295        O3         2397   \n",
+       "0     3.46     3.98    117.82       True      1295        O3         2397   \n",
+       "1     2.57     3.04    108.86       True      1111       Nam         2400   \n",
        "2     3.02     3.98    166.54      False      2397       Nam         1295   \n",
        "\n",
        "  ACCEPTORTYPE                  LIGCOO                  PROTCOO  \n",
-       "0           O2   (3.33, 1.358, 24.276)  (2.686, -1.609, 24.166)  \n",
-       "1          Nam  (4.501, 2.341, 22.538)    (4.854, 4.81, 19.435)  \n",
+       "0          Nam  (4.501, 2.341, 22.538)    (4.854, 4.81, 19.435)  \n",
+       "1           O2   (3.33, 1.358, 24.276)  (2.686, -1.609, 24.166)  \n",
        "2           O3  (4.501, 2.341, 22.538)    (4.854, 4.81, 19.435)  "
       ]
      },
@@ -5239,6 +5240,95 @@
     "            if dataframe is not None:\n",
     "                display(Markdown(\"### {}\".format(interaction_type)))\n",
     "                display(dataframe)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 3D Visualization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def visualize(pdb):\n",
+    "    color_map = {\n",
+    "        'hydrophobic': [0.90, 0.10, 0.29],\n",
+    "        'hbond': [0.26, 0.83, 0.96],\n",
+    "        'waterbridge': [1.00, 0.88, 0.10],\n",
+    "        'saltbridge': [0.67, 1.00, 0.76],\n",
+    "        'pistacking': [0.75, 0.94, 0.27],\n",
+    "        'pication': [0.27, 0.60, 0.56],\n",
+    "        'halogen': [0.94, 0.20, 0.90],\n",
+    "        'metal': [0.90, 0.75, 1.00],\n",
+    "    }\n",
+    "    ffilename = os.path.join(data, pdb)\n",
+    "    viewer = nv.NGLWidget(height=\"600px\", default=True, gui=True)\n",
+    "    prot_component = viewer.add_component(ffilename, ext=\"pdb\")\n",
+    "\n",
+    "    example_site = interactions[pdb][\"LIG:A:1101\"]\n",
+    "    interacting_residues = []\n",
+    "    for sitename, site in interactions[pdb].items():\n",
+    "        if not sitename.startswith(\"LIG\"):\n",
+    "            continue\n",
+    "        for interaction_type, interaction_list in site.items():\n",
+    "            color = color_map[interaction_type]\n",
+    "            if len(interaction_list) == 1:\n",
+    "                continue\n",
+    "            df_interactions = pd.DataFrame.from_records(interaction_list[1:], columns=interaction_list[0])\n",
+    "            for _, interaction in df_interactions.iterrows():\n",
+    "                name = interaction_type\n",
+    "                viewer.shape.add_cylinder(interaction['LIGCOO'], interaction['PROTCOO'], color, [0.1], name) \n",
+    "                interacting_residues.append(interaction['RESNR'])\n",
+    "    # Display interacting residues\n",
+    "    res_sele = \" or \".join([\"({} and not _H)\".format(r) for r in interacting_residues])\n",
+    "    res_sele_nc = \" or \".join([\"({} and ((_O) or (_N) or (_S)))\".format(r) for r in interacting_residues])\n",
+    "    prot_component.add_ball_and_stick(sele=res_sele, colorScheme=\"chainindex\", aspectRatio=1.5)\n",
+    "    prot_component.add_ball_and_stick(sele=res_sele_nc, colorScheme=\"element\", aspectRatio=1.5)\n",
+    "        \n",
+    "    return viewer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "87d5304f628f4cb69fbb4fab349ed7a8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "NGLWidget()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7db108ef656743668f65a25307057b57",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VGFiKGNoaWxkcmVuPShCb3goY2hpbGRyZW49KEJveChjaGlsZHJlbj0oQm94KGNoaWxkcmVuPShMYWJlbCh2YWx1ZT11J3N0ZXAnKSwgSW50U2xpZGVyKHZhbHVlPTEsIG1pbj0tMTAwKSksIGzigKY=\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "visualize(\"Mpro-x0540.pdb\")"
    ]
   }
  ],


### PR DESCRIPTION
I took some code from [Talktorial 11c in TeachOpenCADD](https://github.com/volkamerlab/TeachOpenCADD/blob/master/talktorials/11_online_apis/11c_quality_assessment.ipynb), which made this really straightforward. Also played a bit with `Markdown()` objects for rich-text output, it's so cool!

The current notebook only lists interactions in `LIG`-labeled sites, but there are no stats yet.